### PR TITLE
Updated links in the documentation

### DIFF
--- a/docs/puromodeler.md
+++ b/docs/puromodeler.md
@@ -6,7 +6,7 @@ You can access it at [puromodeler.vse.cz](https://puromodeler.vse.cz).
 
 ## Authors
 
-* Marek Dudáš
+* [Marek Dudáš](https://github.com/marek-dudas)
 * [Vojtěch Svátek](https://nb.vse.cz/~svatek/)
 
 ## Acknowledgments

--- a/docs/puromodeler.md
+++ b/docs/puromodeler.md
@@ -2,7 +2,7 @@
 
 PURO Modeler is a graphical authoring tool for PURO models.
 
-You can access it at [protegeserver.cz/purom5](http://protegeserver.cz/purom5).
+You can access it at [puromodeler.vse.cz](https://puromodeler.vse.cz).
 
 ## Authors
 

--- a/docs/puromodeler.md
+++ b/docs/puromodeler.md
@@ -7,7 +7,7 @@ You can access it at [puromodeler.vse.cz](https://puromodeler.vse.cz).
 ## Authors
 
 * Marek Dudáš
-* [Vojtěch Svátek](https://nb.vse.cz/~svatek/topics.htm)
+* [Vojtěch Svátek](https://nb.vse.cz/~svatek/)
 
 ## Acknowledgments
 


### PR DESCRIPTION
The old link to the deployment of PURO modeler at protegeserver.cz is no longer valid.
There's new deployment at puromodeler.vse.cz.